### PR TITLE
author last name first initial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 target
 project/target
-
+.idea

--- a/src/main/scala/org/allenai/scholar/metrics/metadata/MetadataErrorAnalysis.scala
+++ b/src/main/scala/org/allenai/scholar/metrics/metadata/MetadataErrorAnalysis.scala
@@ -11,13 +11,14 @@ object MetadataErrorAnalysis {
     predictions: Map[String, PaperMetadata]
   ) =
     ErrorAnalysis.computeMetrics(truth, predictions,
-      YEAR -> extractYear _,
-      VENUE_NONEMPTY -> extractVenueNonEmpty _,
-      AUTHOR_FULL_NAME -> extractAuthorExact _,
-      AUTHOR_NORMALIZED_LAST_NAME -> extractAuthorLastName _,
-      TITLE_EXACT -> extractTitleExact _,
-      TITLE_NORMALIZED -> extractTitleNormalized _,
-      TITLE_NONEMPTY -> extractTitleNonempty _)
+      YEAR -> extractYear,
+      VENUE_NONEMPTY -> extractVenueNonEmpty,
+      AUTHOR_FULL_NAME -> extractAuthorExact,
+      AUTHOR_NORMALIZED_LAST_NAME -> extractAuthorLastName,
+      AUTHOR_NORMALIZED_LAST_NAME_FIRST_INITIAL -> extractAuthorLastNameFirstInitial,
+      TITLE_EXACT -> extractTitleExact,
+      TITLE_NORMALIZED -> extractTitleNormalized,
+      TITLE_NONEMPTY -> extractTitleNonempty)
 
   def extractYear(data: PaperMetadata): Iterable[Year] = PublicationYear.ifDefined(data.year)
 
@@ -25,7 +26,11 @@ object MetadataErrorAnalysis {
 
   def extractAuthorExact(data: PaperMetadata): Iterable[Author] = data.authors
 
-  def extractAuthorLastName(data: PaperMetadata): Iterable[Author] = data.authors.map(_.lastNameOnly.normalized)
+  def extractAuthorLastName(data: PaperMetadata): Iterable[Author] =
+    data.authors.map(_.lastNameOnly.normalized)
+
+  def extractAuthorLastNameFirstInitial(data: PaperMetadata): Iterable[Author] =
+    data.authors.map(_.lastNameFirstInitial.normalized)
 
   def extractTitleExact(data: PaperMetadata): Iterable[Title] = data.title.ifDefined
 
@@ -36,6 +41,7 @@ object MetadataErrorAnalysis {
   private val YEAR = "year"
   private val AUTHOR_FULL_NAME = "authorFullName"
   private val AUTHOR_NORMALIZED_LAST_NAME = "authorLastNameNormalized"
+  private val AUTHOR_NORMALIZED_LAST_NAME_FIRST_INITIAL = "authorLastNameNormalizedFirstInitial"
   private val TITLE_EXACT = "titleExact"
   private val TITLE_NORMALIZED = "titleNormalized"
   private val TITLE_NONEMPTY = "titleNonEmpty"


### PR DESCRIPTION
Many "errors" on the ACL data set are due to middle initial issues, and aren't even errors: sometimes the paper doesn't have the middle initial, but the ACL "ground truth" includes it from some other source. Less commonly, it found, but the ground truth has it missing.

In general, I think tracking the (normalized) last name + first initial is probably a better blend of search engine data quality, but regardless, middle names should probably not be worried about (does e.g. elasticsearch even index single character tokens?  Many default Lucene installations have each letter of the alphabet as member of the stop-word set).
